### PR TITLE
Allow `version` to match on multiple conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,23 +51,10 @@ Install the project.
 poetry install -E prospector -E flake8
 ```
 
-Bootstrap the linter. This will ensure all of the expected linters are
-available.
+Bootstrap pyright using pyproper. This will ensure pyright is downloaded
 
 ```
-poetry run lint --bootstrap
-```
-
-Lint all of the python files in the `src` and `tests` directories.
-
-```
-poetry run lint src/ tests/
-```
-
-Run autoupgrade
-
-```
-poetry run autoupgrade
+poetry run pyproper --bootstrap
 ```
 
 ## Contributing
@@ -91,10 +78,10 @@ Install and use the linters
 ```
 # Install all linters
 poetry add --dev ly_python_tools@latest -E prospector -E flake8
-# Ensure all linters are available
-poetry run lint --bootstrap
+# Ensure pyright is downloaded
+poetry run pyproper --bootstrap
 # Run the linters
-poetry run lint .
+poetry run pyproper
 ```
 
 Upgrade all dev-dependencies

--- a/poetry.lock
+++ b/poetry.lock
@@ -209,6 +209,14 @@ optional = true
 python-versions = "*"
 
 [[package]]
+name = "expandvars"
+version = "0.9.0"
+description = "Expand system variables Unix style"
+category = "main"
+optional = false
+python-versions = ">=3.4"
+
+[[package]]
 name = "filelock"
 version = "3.6.0"
 description = "A platform independent file lock."
@@ -941,7 +949,7 @@ prospector = ["prospector"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "276d7f0fc3ec66ddc5f57f73b1bfe2bd7bbc91688e8467c841458326e261a658"
+content-hash = "d189336dd337ccc17cf0d557915184888b9c5feefb0dbca0ae0b607dcafba552"
 
 [metadata.files]
 "aspy.refactor-imports" = [
@@ -1075,6 +1083,10 @@ docutils = [
 dodgy = [
     {file = "dodgy-0.2.1-py3-none-any.whl", hash = "sha256:51f54c0fd886fa3854387f354b19f429d38c04f984f38bc572558b703c0542a6"},
     {file = "dodgy-0.2.1.tar.gz", hash = "sha256:28323cbfc9352139fdd3d316fa17f325cc0e9ac74438cbba51d70f9b48f86c3a"},
+]
+expandvars = [
+    {file = "expandvars-0.9.0-py3-none-any.whl", hash = "sha256:ae90b9c6167e876a0d67892ae18cf2c1ea2e336b2b5542113239d33bf9267497"},
+    {file = "expandvars-0.9.0.tar.gz", hash = "sha256:6a0e7821e55ff1ab44f8ca08b50d2b2d01c076a9bc979da940467cb7f105c565"},
 ]
 filelock = [
     {file = "filelock-3.6.0-py3-none-any.whl", hash = "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,27 @@ behave = "^1.2.6"
 [tool.version]
 version_path = "src/ly_python_tools/__init__.py"
 pep440_check = true
-handlers = [
-    { env = "CIRCLE_TAG", match = '^v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*))', repo = "${ARTIFACTORY_URL}/api/pypi/leapyear-pypi-release-local", validate = true },
-    { env = "CIRCLE_BRANCH", match = '^main$', repo = "${ARTIFACTORY_URL}/api/pypi/leapyear-pypi-snapshot-local", extra = "a${CIRCLE_BUILD_NUM}+${CIRCLE_SHA1}" },
-    { repo = "${ARTIFACTORY_URL}/api/pypi/leapyear-pypi-scratch-local", extra = ".dev${CIRCLE_BUILD_NUM}+${CIRCLE_SHA1}" }
-]
+
+[[tool.version.handlers]]
+# Tagged releases
+repo = "${ARTIFACTORY_URL}/api/pypi/leapyear-pypi-release-local"
+tag_env = "CIRCLE_TAG"
+tag_match = '^v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*))$'
+branch_env = "CIRCLE_BRANCH"
+branch_match = '^main$'
+tag_validate = true
+
+[[tool.version.handlers]]
+# main branch
+repo = "${ARTIFACTORY_URL}/api/pypi/leapyear-pypi-snapshot-local"
+branch_env = "CIRCLE_BRANCH"
+branch_match = '^main$'
+extra = "a${CIRCLE_BUILD_NUM}+${CIRCLE_SHA1:0:7}"
+
+[[tool.version.handlers]]
+# branches from developers
+repo = "${ARTIFACTORY_URL}/api/pypi/leapyear-pypi-scratch-local"
+extra = ".dev${CIRCLE_BUILD_NUM}+${CIRCLE_SHA1:0:7}"
 
 [tool.black]
 line-length = 99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ toml = "^0.10.2"
 poetry-core = "^1.0.8"
 pep440 = "^0.1.0"
 reorder-python-imports = "^3.0.1"
+expandvars = "^0.9.0"
 
 [tool.poetry.extras]
 flake8 = ["flake8", "flake8-print"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ly-python-tools"
-version = "0.1.1"
+version = "0.1.1.dev1234+1234567"
 description = ""
 authors = ["Liam Damewood <liam@leapyear.io>"]
 
@@ -41,22 +41,26 @@ pep440_check = true
 [[tool.version.handlers]]
 # Tagged releases
 repo = "${ARTIFACTORY_URL}/api/pypi/leapyear-pypi-release-local"
-tag_env = "CIRCLE_TAG"
-tag_match = '^v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*))$'
-branch_env = "CIRCLE_BRANCH"
-branch_match = '^main$'
-tag_validate = true
+matchers = [
+    { env = "CIRCLE_TAG", pattern = '^v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*))$', validate = true },
+    { env = "CIRCLE_BRANCH", pattern = '^main$' }
+]
 
 [[tool.version.handlers]]
 # main branch
 repo = "${ARTIFACTORY_URL}/api/pypi/leapyear-pypi-snapshot-local"
-branch_env = "CIRCLE_BRANCH"
-branch_match = '^main$'
+matchers = [
+    { env = "CIRCLE_TAG", pattern = '^$' },
+    { env = "CIRCLE_BRANCH", pattern = '^main$' }
+]
 extra = "a${CIRCLE_BUILD_NUM}+${CIRCLE_SHA1:0:7}"
 
 [[tool.version.handlers]]
 # branches from developers
 repo = "${ARTIFACTORY_URL}/api/pypi/leapyear-pypi-scratch-local"
+matchers = [
+    { env = "CIRCLE_TAG", pattern = '^$' }
+]
 extra = ".dev${CIRCLE_BUILD_NUM}+${CIRCLE_SHA1:0:7}"
 
 [tool.black]

--- a/src/ly_python_tools/version.py
+++ b/src/ly_python_tools/version.py
@@ -122,6 +122,8 @@ class VersionApp:
                     "w"
                 ) as out:
                     for token in tokenize.generate_tokens(read.readline):
+                        if token.type == tokenize.NL:
+                            out.write(token.line)
                         if token.type == tokenize.NEWLINE:
                             out.write(matcher.sub(version_string, token.line))
                 shutil.copy(outfile, self.config.version_path)

--- a/src/ly_python_tools/version.py
+++ b/src/ly_python_tools/version.py
@@ -248,8 +248,10 @@ class Matcher:
     @property
     @lru_cache()
     def _matched(self) -> Match[str] | None:
-        # The matched pattern
-        return self.pattern.match(os.getenv(self.env, ""))  # pylint: disable=invalid-envvar-value
+        """Return the matched pattern."""
+        # Lint false-positive: https://github.com/PyCQA/pylint/issues/5091
+        # pylint: disable=invalid-envvar-value
+        return self.pattern.match(os.getenv(self.env, ""))
 
     def match_env(self) -> bool:
         """Return True if the environment variable matches the pattern."""

--- a/src/ly_python_tools/version.py
+++ b/src/ly_python_tools/version.py
@@ -18,6 +18,7 @@ from typing import Sequence
 import click
 import pep440
 import toml
+from expandvars import expandvars
 from poetry.core.version.version import Version
 
 from .config import get_pyproject
@@ -44,7 +45,7 @@ def main(repo: bool):
     if not repo:
         app.apply_version()
     if repo and app.repo:
-        click.echo(os.path.expandvars(app.repo))
+        click.echo(expandvars(app.repo))
 
 
 @dataclass(frozen=True)
@@ -88,7 +89,7 @@ class VersionApp:
     def full_version(self) -> str:
         """Return the version including all of the extra environment tags."""
         base_version = str(Version(self.project_version).base_version)  # type: ignore
-        return base_version + os.path.expandvars(self.handler.extra)
+        return base_version + expandvars(self.handler.extra)
 
     @property
     def repo(self) -> str | None:

--- a/typings/expandvars/__init__.pyi
+++ b/typings/expandvars/__init__.pyi
@@ -1,0 +1,11 @@
+# pylint: disable=all
+# flake8: noqa
+class ExpandvarsException(Exception):
+    """The base exception for all the handleable exceptions."""
+
+    ...
+
+class UnboundVariable(ExpandvarsException, KeyError):
+    def __init__(self, param: str) -> None: ...
+
+def expandvars(vars_: str, nounset: bool = ...) -> str: ...


### PR DESCRIPTION
Example: Match on main branch and empty tag

```toml
matchers = [
    { env = "CIRCLE_TAG", pattern = '^$' },
    { env = "CIRCLE_BRANCH", pattern = '^main$' }
]
```