### PR TITLE
MAINT: use latest python orb v2.0.X

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  python: circleci/python@2.0.3
+  python: circleci/python@2.0
   circleci-cli: circleci/circleci-cli@0.1.9
 commands:
   setup-artifactory:


### PR DESCRIPTION
The original intent for creating a PR here was to switchover to CCI server, but no config changes were actually required for that.

So instead, I've made a nearly empty commit to show commit tests running on CCI server.

* [x] upon those tests passing, this repo will be turned off for our Cloud CCI